### PR TITLE
Adding Staging Environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
   auto-deploy-to-prod:
     runs-on: ubuntu-latest
     needs: [build, js-tests, static-analysis]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/production'
     steps:
       - uses: actions/checkout@v2
       - name: Download Artifact
@@ -67,5 +67,23 @@ jobs:
         uses: w9jds/firebase-action@master
         with:
           args: deploy --only hosting:cruzhacks-2021-website
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+  auto-deploy-to-test:
+    runs-on: ubuntu-latest
+    needs: [build, js-tests, static-analysis]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: build
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only hosting:cruzhacks-2021-website-test
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
Problem
=======
As part of our development lifecycle this year, we will have a staging and production environment. [This article](https://dev.to/flippedcoding/difference-between-development-stage-and-production-d0p) highlights the key differences between a development, staging, and production environment. Having a staging & production environment will allow us to continue developing code in a test environment while not touching what we have up in production. 

Solution
========
I have created a test and production environment on Firebase. Our test/staging environment will live at [https://cruzhacks-2021-website-test.web.app/](https://cruzhacks-2021-website-test.web.app/) and will live on the `main` branch. Our production site will live at our [https://cruzhacks-2021-website.web.app/](https://cruzhacks-2021-website.web.app/) which will soon be turned to redirect to our domain name & will also live on the `production` branch. We will `cherry-pick` commits from `main => production` to deploy to production. 

**Every PR containing either a feature or a chore/bug fix has to be against `main`. Eric and I will set up deploy trains to production either weekly, bi-weekly, or on a need-basis.** 

Change summary:
---------------
* added staging environment 24cafb0
