### PR TITLE
Addition of Hero Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",
@@ -49,6 +50,7 @@
     ]
   },
   "devDependencies": {
+    "@types/prop-types": "^15.7.3",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "@typescript-eslint/parser": "4.0.1",
     "enzyme": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "@types/classnames": "^2.2.10",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.1",
+    "@types/prop-types": "^15.7.3",
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6",
@@ -51,8 +53,6 @@
     ]
   },
   "devDependencies": {
-    "@types/classnames": "^2.2.10",
-    "@types/prop-types": "^15.7.3",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "@typescript-eslint/parser": "4.0.1",
     "enzyme": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^16.9.49",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6",
+    "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -50,6 +51,7 @@
     ]
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.10",
     "@types/prop-types": "^15.7.3",
     "@typescript-eslint/eslint-plugin": "4.0.1",
     "@typescript-eslint/parser": "4.0.1",

--- a/src/components/PostcardStack/index.view.tsx
+++ b/src/components/PostcardStack/index.view.tsx
@@ -1,8 +1,21 @@
 import React from "react";
+import PropTypes from "prop-types";
 import "./PostcardStack.scss";
 
-const PostcardStack: React.FC = () => {
-  return <div className="PostcardStack">Hello from PostcardStack</div>;
+type PostcardStackProps = {
+  pageName: string;
+};
+
+const PostcardStack: React.FC<PostcardStackProps> = ({ pageName }) => {
+  return (
+    <div className="PostcardStack">
+      Hello from PostcardStack sent from {pageName}
+    </div>
+  );
 };
 
 export default PostcardStack;
+
+PostcardStack.propTypes = {
+  pageName: PropTypes.string.isRequired,
+};

--- a/src/images/arrow.svg
+++ b/src/images/arrow.svg
@@ -1,0 +1,6 @@
+<svg width="95" height="95" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="47.487" cy="47.344" r="46.945" fill="#4F728E"/>
+    <rect x="44.998" y="21.823" width="4.815" height="40.727" rx="2.408" transform="rotate(-45 44.998 21.823)" fill="#fff"/>
+    <rect width="4.815" height="40.727" rx="2.408" transform="scale(1 -1) rotate(-45 -65.456 -90.75)" fill="#fff"/>
+    <rect x="17.773" y="45.108" width="54.448" height="4.782" rx="2.391" fill="#fff"/>
+</svg>

--- a/src/images/placeholder.txt
+++ b/src/images/placeholder.txt
@@ -1,1 +1,0 @@
-Delete this once first image is put in here

--- a/src/images/placeholder.txt
+++ b/src/images/placeholder.txt
@@ -1,0 +1,1 @@
+Delete this once first image is put in here

--- a/src/stylesheets/_variables.scss
+++ b/src/stylesheets/_variables.scss
@@ -2,6 +2,7 @@
   --black: #000;
   --white: #fff;
   --wedgewood: #4f728e;
+  --grey: #bfbfbf;
 
   /* These are for gradient */
   --wedgewood__gradient: #486988;

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -1,5 +1,17 @@
-// stylelint-disable at-rule-disallowed-list
+/* stylelint-disable at-rule-disallowed-list, selector-max-id, selector-max-compound-selectors */
 @import "_fonts";
 @import "_variables";
 @import "_spacers";
-// stylelint-enable
+
+html,
+body,
+#root,
+#root > div {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overscroll-behavior: contain;
+}
+
+/* stylelint-enable */

--- a/src/views/Hero/Hero.scss
+++ b/src/views/Hero/Hero.scss
@@ -1,3 +1,11 @@
-/* stylelint-disable-line no-empty-source */
+.HeroView {
+  height: 100%;
+}
 
-/* Delete these lines when you begin development */
+.HeroView__homeView {
+  background: linear-gradient(180deg, var(--wedgewood__gradient) 0%, var(--waterleaf) 100%);
+  height: 90%;
+  border-bottom-left-radius: 50px;
+  border-bottom-right-radius: 50px;
+  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.25);
+}

--- a/src/views/Hero/Hero.scss
+++ b/src/views/Hero/Hero.scss
@@ -1,11 +1,11 @@
 .HeroView {
   height: 100%;
-}
 
-.HeroView__homeView {
-  background: linear-gradient(180deg, var(--wedgewood__gradient) 0%, var(--waterleaf) 100%);
-  height: 90%;
-  border-bottom-left-radius: 50px;
-  border-bottom-right-radius: 50px;
-  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.25);
+  &__homeView {
+    background: linear-gradient(180deg, var(--wedgewood__gradient) 0%, var(--waterleaf) 100%);
+    height: 90%;
+    border-bottom-left-radius: 50px;
+    border-bottom-right-radius: 50px;
+    box-shadow: 0 10px 16px rgba(0, 0, 0, 0.25);
+  }
 }

--- a/src/views/Hero/Hero.scss
+++ b/src/views/Hero/Hero.scss
@@ -1,0 +1,3 @@
+/* stylelint-disable-line no-empty-source */
+
+/* Delete these lines when you begin development */

--- a/src/views/Hero/index.view.tsx
+++ b/src/views/Hero/index.view.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import PropTypes from "prop-types";
+import PostcardStack from "components/PostcardStack/index.view";
+import EmailSubscriptionForm from "components/EmailSubscription/index.view";
+import "./Hero.scss";
+
+type HeroProps = {
+  pageName: string;
+};
+
+const HeroView: React.FC<HeroProps> = ({ pageName }) => {
+  return (
+    <div className="HeroView">
+      <PostcardStack pageName={pageName} />
+      <EmailSubscriptionForm />
+      Hello from HeroView
+    </div>
+  );
+};
+
+export default HeroView;
+
+HeroView.propTypes = {
+  pageName: PropTypes.string.isRequired,
+};

--- a/src/views/Hero/index.view.tsx
+++ b/src/views/Hero/index.view.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 import PostcardStack from "components/PostcardStack/index.view";
 import EmailSubscriptionForm from "components/EmailSubscription/index.view";
 import "./Hero.scss";
@@ -10,7 +11,9 @@ type HeroProps = {
 
 const HeroView: React.FC<HeroProps> = ({ pageName }) => {
   return (
-    <div className="HeroView">
+    <div
+      className={cx("HeroView", { HeroView__homeView: pageName === "Home" })}
+    >
       <PostcardStack pageName={pageName} />
       <EmailSubscriptionForm />
       Hello from HeroView

--- a/src/views/Hero/index.view.tsx
+++ b/src/views/Hero/index.view.tsx
@@ -7,9 +7,11 @@ import "./Hero.scss";
 
 type HeroProps = {
   pageName: string;
+  title: string;
+  description: string;
 };
 
-const HeroView: React.FC<HeroProps> = ({ pageName }) => {
+const HeroView: React.FC<HeroProps> = ({ pageName, title, description }) => {
   return (
     <div
       className={cx("HeroView", { HeroView__homeView: pageName === "Home" })}
@@ -17,6 +19,8 @@ const HeroView: React.FC<HeroProps> = ({ pageName }) => {
       <PostcardStack pageName={pageName} />
       <EmailSubscriptionForm />
       Hello from HeroView
+      {title}
+      {description}
     </div>
   );
 };
@@ -25,4 +29,6 @@ export default HeroView;
 
 HeroView.propTypes = {
   pageName: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
 };

--- a/src/views/Home/Home.scss
+++ b/src/views/Home/Home.scss
@@ -1,3 +1,3 @@
-/* stylelint-disable-line no-empty-source */
-
-/* Delete these lines when you begin development */
+.Homepage {
+  height: 100%;
+}

--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -1,9 +1,15 @@
 import React from "react";
+import HeroView from "views/Hero/index.view";
 
 import "./Home.scss";
 
 const HomepageView: React.FC = () => {
-  return <div className="Homepage">Hello from HomepageView</div>;
+  return (
+    <div className="Homepage">
+      Hello from HomepageView
+      <HeroView pageName={"Home"} />
+    </div>
+  );
 };
 
 export default HomepageView;

--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -8,7 +8,7 @@ const HomepageView: React.FC = () => {
   return (
     <div className="Homepage">
       <Navbar />
-      <HeroView pageName={"Home"} />
+      <HeroView pageName={"Home"} title={"Title"} description={"Description"} />
     </div>
   );
 };

--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import HeroView from "views/Hero/index.view";
+import Navbar from "components/Navbar/index.view";
 
 import "./Home.scss";
 
 const HomepageView: React.FC = () => {
   return (
     <div className="Homepage">
-      Hello from HomepageView
+      <Navbar />
       <HeroView pageName={"Home"} />
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,6 +1617,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/classnames@^2.2.10":
+  version "2.2.10"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.10.tgz#cc658ca319b6355399efc1f5b9e818f1a24bf999"
+  integrity sha512-1UzDldn9GfYYEsWWnn/P4wkTlkZDH7lDb0wBMGbtIQc9zXEQq7FlKBdZUn6OBqD8sKZZ2RQO2mAjGpXiDGoRmQ==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -3328,6 +3333,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@^4.2.3:
   version "4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1710,7 +1710,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==


### PR DESCRIPTION
Problem
=======
As a developer, 
I want to see a boilerplated hero component, 
So I can focus on implementing my specific component 

[Link to Asana Ticket](https://app.asana.com/0/1197738625416321/1198489500602053/f)

Solution
========
In order to refactor the hero component for our future postcard components, we created a `Hero Component` which take in the following props: `pageName`, `title`, and `description`. These props will be used within the `Hero` component to render the hero for each specific view `Schedule`, `FAQ`, etc. In order to do some further refactoring, we have added a `pageName` prop to `PostcardStack` component to have it render the given postcard in any view. 

Change summary:
---------------
* added hero view and images folder 3ec86c0
* implemented background c24a4f1
* added additional props to hero view 76bf456

Steps to Verify:
----------------
1. Check this branch out and start a local server 
1. Verify that the gradient background is visible & responsive 

Screenshots:
-----------------------
<img width="1440" alt="Screen Shot 2020-10-15 at 10 06 00 PM" src="https://user-images.githubusercontent.com/40477553/96215348-9f47db00-0f32-11eb-8d00-9434cbf44687.png">
