### PR TITLE
used createElement to add mailTo link

### DIFF
--- a/src/components/EmailSubscription/EmailSubscription.scss
+++ b/src/components/EmailSubscription/EmailSubscription.scss
@@ -55,4 +55,8 @@
     color: var(--wedgewood-dark);
     opacity: 0.5;
   }
+
+  &__mailToLink {
+    color: var(--wedgewood-dark);
+  }
 }

--- a/src/components/EmailSubscription/index.view.tsx
+++ b/src/components/EmailSubscription/index.view.tsx
@@ -4,16 +4,25 @@ import { ReactComponent as Arrow } from "images/arrow.svg";
 
 import "./EmailSubscription.scss";
 const subscriptionEndpoint = process.env.REACT_APP_SUBSCRIBE_ENDPOINT || "";
+const cruzHacksEmail = "dev@cruzhacks.com";
 const EmailSubscriptionForm: React.FC = () => {
   const [userEmail, setUserEmail] = useState("");
-  const [feedbackMessage, setFeedbackMessage] = useState("");
+  const [feedbackComponent, setFeedbackComponent] = useState(
+    React.createElement("span")
+  );
   const [showFeedback, setShowFeedback] = useState(true);
   const [showInput, setShowInput] = useState(true);
 
   const submitEmail = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setShowFeedback(true);
-    setFeedbackMessage("Please wait while your message is being submitted...");
+    setFeedbackComponent(
+      React.createElement(
+        "span",
+        { className: "EmailSubscription__feedbackMessage" },
+        "Please wait while your message is being submitted..."
+      )
+    );
     setUserEmail("");
 
     axios
@@ -21,15 +30,40 @@ const EmailSubscriptionForm: React.FC = () => {
         email: userEmail,
       })
       .then((response: AxiosResponse) => {
-        setFeedbackMessage(response.data.message);
+        setFeedbackComponent(
+          React.createElement(
+            "span",
+            { className: "EmailSubscription__feedbackMessage" },
+            response.data.message
+          )
+        );
 
         if (response.status === 200) {
           setShowInput(false);
         }
       })
       .catch(() => {
-        setFeedbackMessage(
-          "Oh no! We've got an error— please try your request again & contact us if this persists!"
+        setFeedbackComponent(
+          React.createElement(
+            "span",
+            { className: "EmailSubscription__feedbackMessage" },
+            [
+              React.createElement(
+                "span",
+                {},
+                "Oh no! We've got an error — please try your request again & "
+              ),
+              React.createElement(
+                "a",
+                {
+                  href: "mailto:" + cruzHacksEmail,
+                  className: "EmailSubscription__mailToLink",
+                },
+                "contact us"
+              ),
+              React.createElement("span", {}, " if this persists"),
+            ]
+          )
         );
       });
   };
@@ -59,9 +93,7 @@ const EmailSubscriptionForm: React.FC = () => {
       )}
       {showFeedback && (
         <div className="EmailSubscription__feedbackContainer">
-          <span className="EmailSubscription__feedbackMessage">
-            {feedbackMessage}
-          </span>
+          {feedbackComponent}
         </div>
       )}
     </>


### PR DESCRIPTION
Problem
=======
As a user,
I would like to contact CruzHacks if I cannot submit my email to the mailing list
to receive timely updates about this years hackathon!

Solution
=======
Use `createElement` to dynamically create a three-part React element that allows users to contact us if email subscriptions do not work properly.

Note that the `__feedbackMessage` class only contains text-relevant styles, so extracting our feedback message into a component with multiple span should not affect is layout overall.

Change summary:
=======
Used `createElement` to create a new feedback component 352c57a643fc7d6c13f2746003581d6461557bf4

Steps to Verify:
=======
Checkout branch using git checkout feature/mailTo-link
Start local development server using yarn start
Open Chrome Developer Tools using CMD/CTRL + SHIFT + I to verify that email subscription component is responsive
Submit email in form to verify that appropriate response component is returned