### PR TITLE
little fix for email input refactor

### DIFF
--- a/src/components/EmailSubscription/index.view.tsx
+++ b/src/components/EmailSubscription/index.view.tsx
@@ -14,7 +14,6 @@ const EmailSubscriptionForm: React.FC = () => {
     event.preventDefault();
     setShowFeedback(true);
     setFeedbackMessage("Please wait while your message is being submitted...");
-    setUserEmail("");
 
     axios
       .post(subscriptionEndpoint, {
@@ -45,6 +44,7 @@ const EmailSubscriptionForm: React.FC = () => {
               aria-label="enter your email address for updates"
               type="email"
               name="email input"
+              onChange={(e) => setUserEmail(e.target.value)}
               required
             />
             <button


### PR DESCRIPTION
Problem
=======
As a new email subscriber, I would like to send a POST request with the actual value of my input, rather than an empty string

Solution
========
Bind email in request with setState() on email input
