### PR TITLE
Patch schedule max-width & scaling

### DIFF
--- a/src/views/Home/components/Footer/footer.scss
+++ b/src/views/Home/components/Footer/footer.scss
@@ -74,6 +74,7 @@
   &__scroll {
     @include footer-highlight();
     height: fit-content;
+    cursor: pointer;
   }
 
   &__arrow {

--- a/src/views/Home/components/Mission/mission.scss
+++ b/src/views/Home/components/Mission/mission.scss
@@ -4,7 +4,7 @@
 
 .Mission {
   position: relative;
-  max-width: 1800px;
+  width: 100vw;
   margin: auto;
 
   /* Background Layer */

--- a/src/views/Home/components/Mission/mission.scss
+++ b/src/views/Home/components/Mission/mission.scss
@@ -23,6 +23,8 @@
 
   &__section {
     z-index: 2;
+    max-width: 70%;
+    margin: auto;
 
     &:first-of-type {
       display: flex;
@@ -96,6 +98,7 @@
     height: 100%;
 
     position: absolute;
+    
     top: 0;
     left: 0;
     z-index: 0;
@@ -103,6 +106,7 @@
 
   &__can--left {
     position: absolute;
+    max-height: 550px;
     width: 18%;
     left: 1%;
     top: 0;
@@ -110,6 +114,7 @@
 
   &__can--right {
     position: absolute;
+    max-height: 550px;
     width: 18%;
     left: 80%;
     top: 32%;
@@ -117,6 +122,7 @@
 
   &__flower {
     position: absolute;
+    max-height: 550px;
     width: 28%;
     left: 5%;
     bottom: 5%;

--- a/src/views/Home/components/Mission/mission.scss
+++ b/src/views/Home/components/Mission/mission.scss
@@ -23,7 +23,7 @@
 
   &__section {
     z-index: 2;
-    max-width: 50%;
+    max-width: 800px;
     margin: auto;
 
     &:first-of-type {

--- a/src/views/Home/components/Mission/mission.scss
+++ b/src/views/Home/components/Mission/mission.scss
@@ -23,7 +23,7 @@
 
   &__section {
     z-index: 2;
-    max-width: 70%;
+    max-width: 50%;
     margin: auto;
 
     &:first-of-type {

--- a/src/views/Home/components/Mission/mission.scss
+++ b/src/views/Home/components/Mission/mission.scss
@@ -96,9 +96,7 @@
     flex-direction: column;
     width: 100%;
     height: 100%;
-
     position: absolute;
-    
     top: 0;
     left: 0;
     z-index: 0;

--- a/src/views/Home/components/Schedule/index.view.tsx
+++ b/src/views/Home/components/Schedule/index.view.tsx
@@ -52,7 +52,18 @@ const scheduleItems = [
   },
 ];
 const ScheduleComponent: React.FC = () => {
-  const [selectedDay, setSelectedDay] = useState(0);
+  const date = new Date();
+  const [selectedDay, setSelectedDay] = useState(
+    date <= new Date(2021, 0, 15)
+      ? 0
+      : date >= new Date(2021, 0, 15) && date < new Date(2021, 0, 16)
+      ? 1
+      : date >= new Date(2021, 0, 16) && date < new Date(2021, 0, 17)
+      ? 2
+      : date >= new Date(2021, 0, 18)
+      ? 0
+      : 0
+  );
   return (
     <div className="Schedule">
       <div className="Schedule__schedule">

--- a/src/views/Home/components/Schedule/schedule.scss
+++ b/src/views/Home/components/Schedule/schedule.scss
@@ -109,7 +109,7 @@
   &__dayThree {
     position: absolute;
     left: -5%;
-    top: calc(59% - 0.05vh);
+    top: calc(59.1%);
   }
 
   &__event {

--- a/src/views/Home/components/Schedule/schedule.scss
+++ b/src/views/Home/components/Schedule/schedule.scss
@@ -97,19 +97,19 @@
   &__dayOne {
     position: absolute;
     left: -5%;
-    top: -7.43%;
+    top: calc(-7.42% - 0.05vh);
   }
 
   &__dayTwo {
     position: absolute;
     left: -5%;
-    top: 25.8%;
+    top: calc(25.8% - 0.05vh);
   }
 
   &__dayThree {
     position: absolute;
     left: -5%;
-    top: 59%;
+    top: calc(59% - 0.05vh);
   }
 
   &__event {

--- a/src/views/Home/components/Schedule/schedule.scss
+++ b/src/views/Home/components/Schedule/schedule.scss
@@ -4,13 +4,29 @@
 .Schedule {
   position: relative;
   z-index: -3;
-  max-width: 1800px;
-  min-height: 800px;
-  height: fit-content;
+  height: calc(75em - 1vw - 10vh);
   margin: auto;
   overflow: hidden;
+  max-width: 100vw;
+
+  @include responsiveness.respond(tab-land) {
+    height: calc(52em - 6vw - 3vh);
+  }
+
+  @include responsiveness.respond(phone) {
+    height: calc(28em - 3vw - 1vh);
+  }
+
+  @include responsiveness.respond(phone-narrow) {
+    height: calc(24em - 3vw - 1vh);
+  }
+
+  @include responsiveness.respond(smallest) {
+    height: calc(17em - 2vw - 0.5vh);
+  }
 
   &__schedule {
+<<<<<<< HEAD
     position: absolute;
     left: 50%;
     margin-left: -32%;
@@ -18,17 +34,24 @@
     width: 75%;
     min-width: min(500px, 70vw);
     padding-bottom: 5%;
+=======
+    position: relative;
+    width: 75%;
+    min-width: min(500px, 70vw);
+>>>>>>> 068b2de... uncap max width of schedule container to match other components
     max-width: 1000px;
-    max-height: 1000px;
-    height: 35%;
+    min-height: auto;
+    height: fit-content;
+    margin: auto;
+    left: calc(1.2vw + 1vh);
+    top: calc(4vw + 2vh);
 
     @include responsiveness.respond(tab-port) {
-      margin-left: -32.5%;
+      top: calc(10vh + 2vw);
     }
 
-    @include responsiveness.respond(phone-narrow) {
-      min-width: 300px;
-      margin-left: min(-125px, -32.5%);
+    @include responsiveness.respond(phone) {
+      top: calc(6vh + 0.25vw);
     }
   }
 
@@ -220,6 +243,11 @@
     bottom: -4px;
     margin-bottom: 5px;
 
+    @include responsiveness.respond(smallest) {
+      bottom: -6px;
+      margin-bottom: 4px;
+    }
+
     &--variant {
       background: linear-gradient(
         270deg,
@@ -286,5 +314,6 @@
     width: 100%;
     height: 100%;
     z-index: -6;
+    top: 0;
   }
 }

--- a/src/views/Home/components/Schedule/schedule.scss
+++ b/src/views/Home/components/Schedule/schedule.scss
@@ -26,19 +26,9 @@
   }
 
   &__schedule {
-<<<<<<< HEAD
-    position: absolute;
-    left: 50%;
-    margin-left: -32%;
-    bottom: 40%;
-    width: 75%;
-    min-width: min(500px, 70vw);
-    padding-bottom: 5%;
-=======
     position: relative;
     width: 75%;
     min-width: min(500px, 70vw);
->>>>>>> 068b2de... uncap max width of schedule container to match other components
     max-width: 1000px;
     min-height: auto;
     height: fit-content;

--- a/src/views/Home/components/Schedule/schedule.scss
+++ b/src/views/Home/components/Schedule/schedule.scss
@@ -109,7 +109,7 @@
   &__dayThree {
     position: absolute;
     left: -5%;
-    top: calc(59.1%);
+    top: 59.1%;
   }
 
   &__event {


### PR DESCRIPTION
Problem
=======
As a widescreen laptop user, I would like to view the schedule component without experiencing a hardcoded max width.
![Screenshot from 2021-01-13 22-54-10](https://user-images.githubusercontent.com/19658882/104555195-4d2a5a80-55f2-11eb-9f5f-eb2df9f0071f.png)
As a developer, I would like to have consistent scaling of all components on the homepage.

Solution
========
The schedule should depend more on relative than absolute positioning. Numerous CSS breakpoints are applied to scale the centered component + background across the entire viewport.  

Screenshots (optional):
-----------------------
![Screenshot from 2021-01-13 22-55-45](https://user-images.githubusercontent.com/19658882/104555586-f96c4100-55f2-11eb-9683-b4389d3ff553.png)
