### PR TITLE
patch dates for conditional schedule tabbing

### DIFF
--- a/src/views/Home/components/Schedule/index.view.tsx
+++ b/src/views/Home/components/Schedule/index.view.tsx
@@ -56,9 +56,9 @@ const ScheduleComponent: React.FC = () => {
   const [selectedDay, setSelectedDay] = useState(
     date <= new Date(2021, 0, 15)
       ? 0
-      : date >= new Date(2021, 0, 15) && date < new Date(2021, 0, 16)
-      ? 1
       : date >= new Date(2021, 0, 16) && date < new Date(2021, 0, 17)
+      ? 1
+      : date >= new Date(2021, 0, 17) && date < new Date(2021, 0, 18)
       ? 2
       : date >= new Date(2021, 0, 18)
       ? 0


### PR DESCRIPTION
Problem
=======
The default schedule tab is 1 day ahead of the actual date, resulting in the schedule rendering a page ahead on default.

![Screenshot from 2021-01-15 00-53-43](https://user-images.githubusercontent.com/19658882/104703555-525bd800-56cc-11eb-86bc-06e86cb1b9d6.png)

Solution
========
Correct ternary conditions by -1 day, so the schedule knows what to render on the appropriate date.

![Screenshot from 2021-01-15 00-53-54](https://user-images.githubusercontent.com/19658882/104703760-92bb5600-56cc-11eb-88f9-03e33135e9ca.png)
