### PR TITLE
Feature: Adding Functionality to access Organizer Applications

### DIFF
--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -12,6 +12,7 @@ import SpeakersComponent from "./components/Speakers/index.view";
 import FAQComponent from "./components/FAQ/index.view";
 import SponsorsComponent from "./components/Sponsors/index.view";
 import FooterComponent from "./components/Footer/index.view";
+import Button from "../../components/Button/index.view";
 
 import { navbarProps } from "./props/navbar.js";
 import * as heroProps from "./props/hero.json";
@@ -22,6 +23,7 @@ import { speakers } from "./props/speakers";
 import * as FAQprops from "./props/faq.json";
 import { sponsors } from "./props/sponsors.js";
 import { footerProps } from "./props/footer";
+import { organizerFormProps } from "./props/organizerForm";
 
 import "./Home.scss";
 
@@ -39,6 +41,9 @@ const HomepageView: React.FC = () => {
           >
             <div className="Homepage__emailSubscriptionContainer">
               <EmailSubscriptionForm />
+            </div>
+            <div className="Homepage__organizerApplication">
+              <Button {...organizerFormProps} />
             </div>
           </Hero>
           <Mission

--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -3,6 +3,7 @@ import Navbar from "components/Navbar/index.view";
 import MLHBanner from "components/MLHBanner/index.view";
 import Background from "components/Background/index.view";
 import Hero from "./components/Hero/index.view";
+import Button from "components/Button/index.view";
 import EmailSubscriptionForm from "components/EmailSubscription/index.view";
 import Mission from "./components/Mission/index.view";
 import MilestonesComponent from "./components/Milestones/index.view";
@@ -12,7 +13,6 @@ import SpeakersComponent from "./components/Speakers/index.view";
 import FAQComponent from "./components/FAQ/index.view";
 import SponsorsComponent from "./components/Sponsors/index.view";
 import FooterComponent from "./components/Footer/index.view";
-import Button from "../../components/Button/index.view";
 
 import { navbarProps } from "./props/navbar.js";
 import * as heroProps from "./props/hero.json";

--- a/src/views/Home/props/navbar.js
+++ b/src/views/Home/props/navbar.js
@@ -9,6 +9,12 @@ export const navbarProps = {
       label: "mlh code of conduct",
       type: ButtonTypes.SECONDARY,
     },
+    organizer_application: {
+      text: "Organizer Applications",
+      link: "https://forms.gle/VJxrg8REVy3R55Cm8",
+      label: "organizer app",
+      type: ButtonTypes.SECONDARY,
+    },
     contact_us: {
       text: "Contact Us",
       link: "mailto:contact@cruzhacks.com",

--- a/src/views/Home/props/organizerForm.js
+++ b/src/views/Home/props/organizerForm.js
@@ -1,7 +1,7 @@
-import { ButtonTypes } from "../../../components/Button/index.view";
+import { ButtonTypes } from "components/Button/index.view";
 
 export const organizerFormProps = {
-  text: "Click Here to Apply to be a CruzHacks Organizer! Due 4/21",
+  text: "Click Here to Apply to be a CruzHacks Organizer! Due 4/23",
   link: "https://forms.gle/VJxrg8REVy3R55Cm8",
   label: "Hello World",
   className: "Navbar__button",

--- a/src/views/Home/props/organizerForm.js
+++ b/src/views/Home/props/organizerForm.js
@@ -1,0 +1,9 @@
+import { ButtonTypes } from "../../../components/Button/index.view";
+
+export const organizerFormProps = {
+  text: "Click Here to Apply to be a CruzHacks Organizer! Due 4/21",
+  link: "https://forms.gle/VJxrg8REVy3R55Cm8",
+  label: "Hello World",
+  className: "Navbar__button",
+  type: ButtonTypes.PRIMARY,
+};


### PR DESCRIPTION
Problem
=======
Users need to be able to easily access the CruzHacks 2022 Organizer Applications.

Solution
========
What I did to solve this problem was I added an additional button within the navbar dropdown menu linking to the organizer applications. I also added near the top of the main container of the main page another button redirecting users to the CruzHacks 2022 Organizer Applications


Change summary:
---------------
* Added functionality for organizer application forms in the navbar and the main container

Screenshots (optional):
-----------------------
Red Outline surrounding changes
![Screen Shot 2021-04-01 at 11 10 39 PM](https://user-images.githubusercontent.com/38510322/113386705-a4adac00-933f-11eb-8fad-e375f11a5f71.png)
