### PR TITLE
Updating Home Page to Revert 2022 Content to 2021

### DIFF
--- a/src/views/Home/index.view.tsx
+++ b/src/views/Home/index.view.tsx
@@ -3,27 +3,27 @@ import Navbar from "components/Navbar/index.view";
 import MLHBanner from "components/MLHBanner/index.view";
 import Background from "components/Background/index.view";
 import Hero from "./components/Hero/index.view";
-import Button from "components/Button/index.view";
+// import Button from "components/Button/index.view";
 import EmailSubscriptionForm from "components/EmailSubscription/index.view";
 import Mission from "./components/Mission/index.view";
 import MilestonesComponent from "./components/Milestones/index.view";
-// import Schedule from "./components/Schedule/index.view";
-// import PrizesComponent from "./components/Prizes/index.view";
-// import SpeakersComponent from "./components/Speakers/index.view";
+import Schedule from "./components/Schedule/index.view";
+import PrizesComponent from "./components/Prizes/index.view";
+import SpeakersComponent from "./components/Speakers/index.view";
 import FAQComponent from "./components/FAQ/index.view";
-// import SponsorsComponent from "./components/Sponsors/index.view";
+import SponsorsComponent from "./components/Sponsors/index.view";
 import FooterComponent from "./components/Footer/index.view";
 
 import { navbarProps } from "./props/navbar.js";
 import * as heroProps from "./props/hero.json";
 import * as missionProps from "./props/mission.json";
 import * as milestoneProps from "./props/milestones.json";
-// import { topics } from "./props/prizes";
-// import { speakers } from "./props/speakers";
+import { topics } from "./props/prizes";
+import { speakers } from "./props/speakers";
 import * as FAQprops from "./props/faq.json";
-// import { sponsors } from "./props/sponsors.js";
+import { sponsors } from "./props/sponsors.js";
 import { footerProps } from "./props/footer";
-import { sponsorFormProps } from "./props/sponsorForm";
+// import { sponsorFormProps } from "./props/sponsorForm";
 
 import "./Home.scss";
 
@@ -42,24 +42,24 @@ const HomepageView: React.FC = () => {
             <div className="Homepage__emailSubscriptionContainer">
               <EmailSubscriptionForm />
             </div>
-            <div className="Homepage__sponsorApplication">
+            {/* <div className="Homepage__sponsorApplication">
               <Button {...sponsorFormProps} />
-            </div>
+            </div> */}
           </Hero>
           <Mission
             about_text={missionProps.about}
             mission_text={missionProps.mission}
           />
           <MilestonesComponent milestones={milestoneProps.milestones} />
-          {/* <PrizesComponent topics={topics} />
+          <PrizesComponent topics={topics} />
           <SpeakersComponent speakers={speakers} />
-          <Schedule /> */}
+          <Schedule />
           <FAQComponent
             questionAnswersColumnLeft={FAQprops.questionAnswersColumnLeft}
             questionAnswersColumnRight={FAQprops.questionAnswersColumnRight}
             questionAnswersColumnMiddle={FAQprops.questionAnswersColumnMiddle}
           />
-          {/* <SponsorsComponent sponsors={sponsors} /> */}
+          <SponsorsComponent sponsors={sponsors} />
           <FooterComponent links={footerProps} />
         </Background>
       </div>

--- a/src/views/Home/props/hero.json
+++ b/src/views/Home/props/hero.json
@@ -1,11 +1,11 @@
 {
   "title": [
     {
-      "text": "CruzHacks 2022 /",
+      "text": "CruzHacks 2021 /",
       "style": ""
     },
     {
-      "text": "January 14-16",
+      "text": "January 15-17",
       "style": "--secondary"
     }
   ],

--- a/src/views/Home/props/navbar.js
+++ b/src/views/Home/props/navbar.js
@@ -1,7 +1,7 @@
 import { ButtonTypes } from "components/Button/index.view";
 
 export const navbarProps = {
-  title: "CruzHacks 2022",
+  title: "CruzHacks 2021",
   buttonProps: Object.values({
     code_conduct: {
       text: "Our Code of Conduct",


### PR DESCRIPTION
Problem
=======
2021 Website Needs to Remove 2022 Data

[Link to Asana Ticket](https://app.asana.com/1234)

Solution
========
* Updated Home Page Props

Change summary:
---------------
* Re-Added Sponsors, Prizes, Speakers, and Schedule 

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] `.env` & `.env.sample` 
- [ ] `webpack.config.js` 
- [ ] GCP Secret Manager
- [ ] Github Secrets 
- [ ] GithubActions Workflow

Steps to Verify:
----------------
1. A setup step / beginning state
2. What to do next
3. Any other instructions
4. Expected behavior
5. Suggestions for testing

Screenshots (optional):
-----------------------
Show-n-tell images/animations here